### PR TITLE
Update hardware requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ safeResult.match(
 - Must be called from a browser extension
 - Chrome 138+ or supported Chromium Browser
 - Enable "Prompt API for Gemini Nano" in `chrome://flags`
-- Update "Optimization Guide On Device Model" in `chrome://components` ⚠️ **Warning: This will download ~22GB**
+- Update "Optimization Guide On Device Model" in `chrome://components`
+  ⚠️ **Warning: This will download ~4GB. See the [hardware requirements](https://developer.chrome.com/docs/ai/get-started#hardware)**
 - Join Chrome [EPP](https://developer.chrome.com/docs/ai/join-epp) for web
 
 ## Core Functions


### PR DESCRIPTION
Hi there! We've updated the hardware requirements to clarify that Chrome does *not* download 22GB for Gemini Nano. However, you must have 22GB of space to ensure there's plenty of buffer.

The model size varies and may be around 4GB.

http://developer.chrome.com/docs/ai/get-started#hardware-requirements