### PR TITLE
Add checkInputUsage to Summarizer API

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,19 @@ const summary2 = await summarizer.summarize("Second article...");
 summarizer.destroy();
 ```
 
+### Input Measurement
+
+Check if input fits within the model's limits before summarizing:
+
+```typescript
+import { Summarizer } from 'simple-chromium-ai';
+
+const usage = await Summarizer.checkInputUsage("Long article...", { type: "tldr" });
+if (usage.willFit) {
+  const summary = await Summarizer.summarize("Long article...", { type: "tldr" });
+}
+```
+
 ## Safe API
 
 Every function has a Safe variant that returns Result types instead of throwing:

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,8 +23,10 @@ export { translate } from "./translator";
 export { translate as safeTranslate } from "./translator-safe";
 // Re-export types for users
 export type {
+	CheckInputUsageResult,
 	ChromiumAIInstance,
 	DetectResult,
+	InputUsageInfo,
 	PromptResult,
 	SummarizeResult,
 	TokenUsageInfo,

--- a/src/summarizer-safe.ts
+++ b/src/summarizer-safe.ts
@@ -1,7 +1,7 @@
 /// <reference types="@types/dom-chromium-ai" />
 
 import { ResultAsync } from "neverthrow";
-import type { SummarizeResult } from "./types";
+import type { CheckInputUsageResult, SummarizeResult } from "./types";
 import { checkAvailability } from "./utils";
 
 /**
@@ -73,6 +73,46 @@ export function summarize(
 				error instanceof Error
 					? error
 					: new Error(`Summarization failed: ${String(error)}`),
+		),
+	);
+}
+
+/**
+ * Checks input usage for a summarization request without performing it.
+ * Creates a temporary Summarizer instance to measure the input, then destroys it.
+ *
+ * @param input The text to measure
+ * @param createOptions Optional creation options (type, format, length, sharedContext)
+ * @param summarizeOptions Optional options for the measurement (context, signal)
+ * @returns A Result containing input usage information or an Error
+ */
+export function checkInputUsage(
+	input: string,
+	createOptions?: SummarizerCreateOptions,
+	summarizeOptions?: SummarizerSummarizeOptions,
+): CheckInputUsageResult {
+	return checkAvailability(
+		() => Summarizer.availability(createOptions),
+		"Summarizer",
+	).andThen(() =>
+		ResultAsync.fromPromise(
+			(async () => {
+				const summarizer = await Summarizer.create(createOptions);
+				try {
+					const inputUsage = await summarizer.measureInputUsage(
+						input,
+						summarizeOptions,
+					);
+					const inputQuota = summarizer.inputQuota || 0;
+					return { inputUsage, inputQuota, willFit: inputUsage <= inputQuota };
+				} finally {
+					summarizer.destroy();
+				}
+			})(),
+			(error) =>
+				error instanceof Error
+					? error
+					: new Error(`Failed to check input usage: ${String(error)}`),
 		),
 	);
 }

--- a/src/summarizer.ts
+++ b/src/summarizer.ts
@@ -1,6 +1,7 @@
 /// <reference types="@types/dom-chromium-ai" />
 
 import * as Safe from "./summarizer-safe";
+import type { InputUsageInfo } from "./types";
 import { okOrThrow } from "./utils";
 
 /**
@@ -36,5 +37,22 @@ export async function summarize(
 	summarizeOptions?: SummarizerSummarizeOptions,
 ): Promise<string> {
 	const result = await Safe.summarize(text, createOptions, summarizeOptions);
+	return okOrThrow(result);
+}
+
+/**
+ * Checks input usage for a summarization request without performing it.
+ * @throws {Error} If input usage check fails
+ */
+export async function checkInputUsage(
+	input: string,
+	createOptions?: SummarizerCreateOptions,
+	summarizeOptions?: SummarizerSummarizeOptions,
+): Promise<InputUsageInfo> {
+	const result = await Safe.checkInputUsage(
+		input,
+		createOptions,
+		summarizeOptions,
+	);
 	return okOrThrow(result);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,3 +33,14 @@ export type TranslateResult = ResultAsync<string, Error>;
 export type DetectResult = ResultAsync<LanguageDetectionResult[], Error>;
 
 export type SummarizeResult = ResultAsync<string, Error>;
+
+/**
+ * Information about input usage for a summarization request
+ */
+export interface InputUsageInfo {
+	inputUsage: number;
+	inputQuota: number;
+	willFit: boolean;
+}
+
+export type CheckInputUsageResult = ResultAsync<InputUsageInfo, Error>;


### PR DESCRIPTION
Add input measurement helper that checks if text fits within the model's limits before summarizing, mirroring the Prompt API's checkTokenUsage.